### PR TITLE
<refact> : 회원 가입페이지 리팩토링

### DIFF
--- a/src/components/Join/JoinForm/style.ts
+++ b/src/components/Join/JoinForm/style.ts
@@ -9,28 +9,6 @@ const JoinSection = styled.section`
   border-radius: 0 0 10px 10px;
 `;
 
-const BuyerrBtn = styled.h2`
-  font-style: normal;
-  font-weight: 500;
-  font-size: 18px;
-  line-height: 22px;
-  border: 1px solid #c4c4c4;
-  border-radius: 10px 10px 0 0;
-  text-align: center;
-  padding: 19px 0;
-  width: 50%;
-  display: inline-block;
-  box-sizing: border-box;
-  cursor: pointer;
-`;
-const SuccessTxt = styled.small`
-  display: block;
-  margin-top: 1rem;
-  font-size: 1.4rem;
-  font-weight: 500;
-  color: ${({ theme }) => theme.colors.green};
-`;
-
 const JoinBtn = styled(Button)`
   margin: auto;
   display: block;
@@ -64,8 +42,6 @@ export const EmailInputWrapper = styled.div`
 
 export const S = {
   JoinSection,
-  BuyerrBtn,
-  SuccessTxt,
   JoinBtn,
   Select,
   EmailInputWrapper,

--- a/src/components/common/RenderErrorMsg/RenderErrorMsg.tsx
+++ b/src/components/common/RenderErrorMsg/RenderErrorMsg.tsx
@@ -1,7 +1,18 @@
 import styled from "styled-components";
 
 function RenderErrorMsg(error: any) {
-  return error && <ErrorText>{error.message?.toString()}</ErrorText>;
+  const errorType = error?.type;
+  const errorMessage = error?.message;
+
+  if (errorType === "success") {
+    return <SuccessTxt>{errorMessage?.toString()}</SuccessTxt>;
+  }
+
+  if (errorType === "fail") {
+    return <ErrorText>{errorMessage?.toString()}</ErrorText>;
+  }
+
+  return null;
 }
 
 export default RenderErrorMsg;
@@ -12,4 +23,12 @@ const ErrorText = styled.small`
   font-size: 1.4rem;
   font-weight: 500;
   color: #eb5757;
+`;
+
+const SuccessTxt = styled.small`
+  display: block;
+  margin-top: 1rem;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.green};
 `;


### PR DESCRIPTION
## 🔶작업사항
- 회원가입 페이지 코드 가독성 & 재사용성 높임

## 🔶변경로직
- 1) 아이디 중복확인 / 사업자 등록번호 인증 SuccessTxt 와 ErrorText 를 react-hook-form 의 setError의 type 별로 구분해서 표시할 수 있게 함
- 2) 아이디 & 사업자 번호 유효성 검증 비동기 통신할 때 중복되는 코드를 createValidationThunk 함수 하나로 합침
- 3) 가입하기 버튼 클릭 후 form 제출 로직에서 handleResultAction 함수를 만들어서 반복되는 코드 줄임

Close #13 
