### PR TITLE
<feat> : 로그인 구현 완성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@types/react-dom": "^18.0.11",
         "axios": "^1.3.4",
         "react": "^18.2.0",
+        "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.43.8",
         "react-redux": "^8.0.5",
@@ -3858,6 +3859,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "node_modules/@types/eslint": {
       "version": "8.21.1",
@@ -14182,6 +14188,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "dependencies": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -16277,6 +16296,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "dependencies": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      }
+    },
+    "node_modules/universal-cookie/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/universalify": {
@@ -19958,6 +19994,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow=="
     },
     "@types/eslint": {
       "version": "8.21.1",
@@ -27340,6 +27381,16 @@
         "whatwg-fetch": "^3.6.2"
       }
     },
+    "react-cookie": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/react-cookie/-/react-cookie-4.1.1.tgz",
+      "integrity": "sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==",
+      "requires": {
+        "@types/hoist-non-react-statics": "^3.0.1",
+        "hoist-non-react-statics": "^3.0.0",
+        "universal-cookie": "^4.0.0"
+      }
+    },
     "react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -28860,6 +28911,22 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-4.0.4.tgz",
+      "integrity": "sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==",
+      "requires": {
+        "@types/cookie": "^0.3.3",
+        "cookie": "^0.4.0"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        }
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/react-dom": "^18.0.11",
     "axios": "^1.3.4",
     "react": "^18.2.0",
+    "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.8",
     "react-redux": "^8.0.5",

--- a/src/components/Join/JoinForm/JoinForm.tsx
+++ b/src/components/Join/JoinForm/JoinForm.tsx
@@ -24,7 +24,7 @@ interface ErrorMessages {
 }
 
 function JoinForm() {
-  const [toggleType, setToggleType] = useState("buyer");
+  const [toggleType, setToggleType] = useState("BUYER");
   const [isJoinValid, setIsJoinValid] = useState(false);
   const [idChecked, setIdChecked] = useState(false);
   const [businessChecked, setBusinessChecked] = useState(false);

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -12,7 +12,6 @@ function LoginForm() {
   const [toggleType, setToggleType] = useState("BUYER");
   const [message, setMessage] = useState("");
   const loginError = useAppSelector((state: RootState) => state.login.error);
-  console.log(loginError);
   const status = useAppSelector((state: RootState) => state.login.status);
 
   const idInput = useRef<HTMLInputElement>(null);

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchLogin } from "../../features/loginSlice";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
@@ -8,15 +8,21 @@ import * as S from "./style";
 
 function LoginForm() {
   const dispatch = useAppDispatch();
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const [toggleType, setToggleType] = useState("BUYER");
+  const [message, setMessage] = useState("");
   const loginError = useAppSelector((state: RootState) => state.login.error);
   console.log(loginError);
+  const status = useAppSelector((state: RootState) => state.login.status);
 
-  const [inputs, setInputs] = useState({
+  const idInput = useRef<HTMLInputElement>(null);
+
+  const initialValues = {
     username: "",
     password: "",
-  });
+  };
+
+  const [inputs, setInputs] = useState(initialValues);
 
   // 아이디 & 비밀번호 입력
   const handleData = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -27,14 +33,31 @@ function LoginForm() {
   // 로그인 폼 제출
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setMessage("");
     const loginData = {
       username: inputs.username,
       password: inputs.password,
       login_type: toggleType,
     };
     await dispatch(fetchLogin(loginData));
-    // navigate("/");
   };
+
+  useEffect(() => {
+    if (status === "failed") {
+      if (loginError === "Rejected") {
+        setMessage("아이디 또는 비밀번호를 입력해주세요");
+      } else {
+        setMessage(loginError); // 로그인 정보 틀릴 시 에러메세지
+      }
+      setInputs(initialValues);
+      if (idInput.current) {
+        idInput.current.focus();
+      }
+    }
+    if (status === "succeeded") {
+      navigate("/");
+    }
+  }, [status, loginError]);
 
   return (
     <section>
@@ -47,6 +70,7 @@ function LoginForm() {
           onChange={handleData}
           name="username"
           value={inputs.username}
+          ref={idInput}
           // required
         />
         <S.LoginInput
@@ -57,7 +81,7 @@ function LoginForm() {
           value={inputs.password}
           // required
         />
-        {loginError ? <S.ErrorText>{loginError}</S.ErrorText> : null}
+        {loginError ? <S.ErrorText>{message}</S.ErrorText> : null}
         <S.LoginBtn type="submit" size="md">
           로그인
         </S.LoginBtn>

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -1,20 +1,63 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchLogin } from "../../features/loginSlice";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import { RootState } from "../../store/store";
 import ToggleBtn from "../common/ToggleBtn/ToggleBtn";
 import * as S from "./style";
 
 function LoginForm() {
-  const [toggleType, setToggleType] = useState("buyer");
+  const dispatch = useAppDispatch();
+  // const navigate = useNavigate();
+  const [toggleType, setToggleType] = useState("BUYER");
+  const loginError = useAppSelector((state: RootState) => state.login.error);
+  console.log(loginError);
 
-  const [message, setMessage] = useState("");
+  const [inputs, setInputs] = useState({
+    username: "",
+    password: "",
+  });
+
+  // 아이디 & 비밀번호 입력
+  const handleData = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setInputs({ ...inputs, [name]: value });
+  };
+
+  // 로그인 폼 제출
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const loginData = {
+      username: inputs.username,
+      password: inputs.password,
+      login_type: toggleType,
+    };
+    await dispatch(fetchLogin(loginData));
+    // navigate("/");
+  };
 
   return (
     <section>
       <h2 className="hidden">로그인 페이지</h2>
       <ToggleBtn toggleType={toggleType} setToggleType={setToggleType} />
-      <S.LoginForm>
-        <S.LoginInput placeholder="아이디" />
-        <S.LoginInput placeholder="비밀번호" />
-        {message ? <S.ErrorText>{message}</S.ErrorText> : null}
+      <S.LoginForm onSubmit={handleSubmit}>
+        <S.LoginInput
+          placeholder="아이디"
+          type="text"
+          onChange={handleData}
+          name="username"
+          value={inputs.username}
+          // required
+        />
+        <S.LoginInput
+          placeholder="비밀번호"
+          type="password"
+          onChange={handleData}
+          name="password"
+          value={inputs.password}
+          // required
+        />
+        {loginError ? <S.ErrorText>{loginError}</S.ErrorText> : null}
         <S.LoginBtn type="submit" size="md">
           로그인
         </S.LoginBtn>

--- a/src/components/LoginForm/style.tsx
+++ b/src/components/LoginForm/style.tsx
@@ -27,6 +27,9 @@ export const LoginInput = styled.input`
   &::placeholder {
     color: ${({ theme }) => theme.colors.lightGray};
   }
+  &:focus {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.green};
+  }
 `;
 
 export const ErrorText = styled.small`

--- a/src/components/common/ToggleBtn/ToggleBtn.tsx
+++ b/src/components/common/ToggleBtn/ToggleBtn.tsx
@@ -8,10 +8,10 @@ interface ToggleBtnProps {
 
 function ToggleBtn({ toggleType, setToggleType }: ToggleBtnProps) {
   const handleToggle = (e: MouseEvent<HTMLButtonElement>) => {
-    if ((e.target as HTMLButtonElement).name === "buyer") {
-      setToggleType("buyer");
+    if ((e.target as HTMLButtonElement).name === "BUYER") {
+      setToggleType("BUYER");
     } else {
-      setToggleType("seller");
+      setToggleType("SELLER");
     }
   };
 
@@ -21,16 +21,16 @@ function ToggleBtn({ toggleType, setToggleType }: ToggleBtnProps) {
     <>
       <S.ToggleWrapper>
         <S.ToggleText
-          name="buyer"
+          name="BUYER"
           value={toggleType}
-          active={toggleType === "buyer"}
+          active={toggleType === "BUYER"}
           onClick={handleToggle}
         >
           {path === "/login" ? "구매회원 로그인" : "구매회원가입"}
         </S.ToggleText>
         <S.ToggleText
-          name="seller"
-          active={toggleType === "seller"}
+          name="SELLER"
+          active={toggleType === "SELLER"}
           value={toggleType}
           onClick={handleToggle}
         >

--- a/src/features/joinSlice.ts
+++ b/src/features/joinSlice.ts
@@ -95,7 +95,7 @@ export const fetchSellerJoin = createAsyncThunk(
     { rejectWithValue }
   ) => {
     try {
-      const response = await axios.post(`${BASE_URL}/accounts/signup_seller/`, {
+      const data = {
         username,
         password,
         password2,
@@ -103,7 +103,11 @@ export const fetchSellerJoin = createAsyncThunk(
         name,
         company_registration_number,
         store_name,
-      });
+      };
+      const response = await axios.post(
+        `${BASE_URL}/accounts/signup_seller/`,
+        data
+      );
       console.log(response.data);
       return response.data;
     } catch (error: any) {

--- a/src/features/loginSlice.ts
+++ b/src/features/loginSlice.ts
@@ -1,9 +1,10 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 import { BASE_URL } from "../constant/config";
+import { setCookie, getCookie } from "../utils/Cookies";
 
-const item = localStorage.getItem("token");
-const TOKEN = item === null ? null : JSON.parse(item).token;
+const item = getCookie("token");
+const TOKEN = item === null ? null : JSON.parse(item || "{}").token;
 
 interface LoginData {
   username: string;
@@ -35,8 +36,8 @@ export const fetchLogin = createAsyncThunk(
       console.log(response.data);
 
       if (response.data) {
-        localStorage.setItem("token", JSON.stringify(response.data.token));
-        localStorage.setItem("user_type", response.data.user_type);
+        setCookie("token", response.data.token);
+        setCookie("userType", response.data.user_type);
       }
       return response.data;
     } catch (error: any) {

--- a/src/features/loginSlice.ts
+++ b/src/features/loginSlice.ts
@@ -28,6 +28,11 @@ export const fetchLogin = createAsyncThunk(
       const data = { username, password, login_type };
       const response = await axios.post(`${BASE_URL}/accounts/login/`, data);
       console.log(response.data);
+
+      // if (response.data) {
+      //   sessionStorage.setItem("token", JSON.stringify(response.data));
+      // }
+      return response.data;
     } catch (error: any) {
       console.log(error.response.data);
       return rejectWithValue(error.response.data.FAIL_Message);

--- a/src/features/loginSlice.ts
+++ b/src/features/loginSlice.ts
@@ -1,0 +1,59 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
+import { BASE_URL } from "../constant/config";
+
+interface LoginData {
+  username: string;
+  password: string;
+  login_type: string;
+}
+
+interface InitalState {
+  status: "loading" | "succeeded" | "failed";
+  error: string;
+}
+
+const initialState: InitalState = {
+  status: "loading",
+  error: "",
+};
+
+export const fetchLogin = createAsyncThunk(
+  "login/fetchLogin",
+  async (
+    { username, password, login_type }: LoginData,
+    { rejectWithValue }
+  ) => {
+    try {
+      const data = { username, password, login_type };
+      const response = await axios.post(`${BASE_URL}/accounts/login/`, data);
+      console.log(response.data);
+    } catch (error: any) {
+      console.log(error.response.data);
+      return rejectWithValue(error.response.data.FAIL_Message);
+    }
+  }
+);
+
+const loginSlice = createSlice({
+  name: "login",
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchLogin.pending, (state) => {
+        state.status = "loading";
+      })
+      .addCase(fetchLogin.fulfilled, (state) => {
+        state.status = "succeeded";
+        state.error = "";
+      })
+      .addCase(fetchLogin.rejected, (state, action) => {
+        state.status = "failed";
+        state.error =
+          (action.payload as string | undefined) || action.error.message || "";
+      });
+  },
+});
+
+export default loginSlice.reducer;

--- a/src/features/loginSlice.ts
+++ b/src/features/loginSlice.ts
@@ -2,20 +2,25 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import axios from "axios";
 import { BASE_URL } from "../constant/config";
 
+const item = localStorage.getItem("token");
+const TOKEN = item === null ? null : JSON.parse(item).token;
+
 interface LoginData {
   username: string;
   password: string;
   login_type: string;
 }
 
-interface InitalState {
+interface LoginState {
   status: "loading" | "succeeded" | "failed";
   error: string;
+  token?: string | null;
 }
 
-const initialState: InitalState = {
+const initialState: LoginState = {
   status: "loading",
   error: "",
+  token: TOKEN ? TOKEN : null,
 };
 
 export const fetchLogin = createAsyncThunk(
@@ -29,9 +34,10 @@ export const fetchLogin = createAsyncThunk(
       const response = await axios.post(`${BASE_URL}/accounts/login/`, data);
       console.log(response.data);
 
-      // if (response.data) {
-      //   sessionStorage.setItem("token", JSON.stringify(response.data));
-      // }
+      if (response.data) {
+        localStorage.setItem("token", JSON.stringify(response.data.token));
+        localStorage.setItem("user_type", response.data.user_type);
+      }
       return response.data;
     } catch (error: any) {
       console.log(error.response.data);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import joinSliceReducer from "../features/joinSlice";
+import loginSliceReducer from "../features/loginSlice";
 
 export const store = configureStore({
   reducer: {
     join: joinSliceReducer,
+    login: loginSliceReducer,
   },
 });
 

--- a/src/utils/Cookies.ts
+++ b/src/utils/Cookies.ts
@@ -1,0 +1,18 @@
+import { Cookies } from "react-cookie";
+
+const cookies = new Cookies();
+
+// 쿠키에 값을 저장할 때
+export const setCookie = (name: string, value: string) => {
+  return cookies.set(name, value, { maxAge: 60 * 60 * 3, path: "/" });
+};
+
+// 쿠키에 있는 값을 꺼낼때
+export const getCookie = (name: string) => {
+  return cookies.get(name);
+};
+
+//쿠키를 지울때
+export const removeCookie = (name: string) => {
+  return cookies.remove(name);
+};


### PR DESCRIPTION
## 🔶작업사항
- 로그인 페이지 에러메세지 관리 
1) 아이디,비밀번호 input 값이 공백인 상태에서 로그인 버튼을 누르면 에러메세지 렌더링
2) input 값 다 채운 후  로그인 정보가 없을 때 에러메세지 렌더링 후 input 값 공백 적용 및 foucus 적용
- 로그인에 성공할 경우 홈 페이지로 이동
- 로그인에 성공 시 서버에서 토큰 값/ userType 받아오면 전역상태에 있는 쿠키로 저장

## 🔶변경로직
- 내용을 적어주세요.


- Close #17 
