### PR TITLE
<refact> : 장바구니 react-query 로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.3",
         "@tanstack/react-query": "^4.29.25",
+        "@tanstack/react-query-devtools": "^4.32.6",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -3484,21 +3485,36 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz",
+      "integrity": "sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
     "node_modules/@tanstack/query-core": {
-      "version": "4.29.25",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.25.tgz",
-      "integrity": "sha512-DI4y4VC6Uw4wlTpOocEXDky69xeOScME1ezLKsj+hOk7DguC9fkqXtp6Hn39BVb9y0b5IBrY67q6kIX623Zj4Q==",
+      "version": "4.32.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.32.6.tgz",
+      "integrity": "sha512-YVB+mVWENQwPyv+40qO7flMgKZ0uI41Ph7qXC2Zf1ft5AIGfnXnMZyifB2ghhZ27u+5wm5mlzO4Y6lwwadzxCA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.29.25",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.25.tgz",
-      "integrity": "sha512-c1+Ezu+XboYrdAMdusK2fTdRqXPMgPAnyoTrzHOZQqr8Hqz6PNvV9DSKl8agUo6nXX4np7fdWabIprt+838dLg==",
+      "version": "4.32.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.32.6.tgz",
+      "integrity": "sha512-AITu/IKJJJXsHHeXNBy5bclu12t08usMCY0vFC2dh9SP/w6JAk5U9GwfjOIPj3p+ATADZvxQPe8UiCtMLNeQbg==",
       "dependencies": {
-        "@tanstack/query-core": "4.29.25",
+        "@tanstack/query-core": "4.32.6",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -3517,6 +3533,25 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.32.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.32.6.tgz",
+      "integrity": "sha512-Gd9pBkm2sbeze9P5Yp8R7y0rZVUdoIOhduomDjz138WdJuVbRS4Y8p6gX2uMJFsUFVe7jA6fX/D6NfQ9o5OS/A==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^4.32.6",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -5935,6 +5970,20 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js": {
       "version": "3.29.1",
@@ -9486,6 +9535,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.15.tgz",
+      "integrity": "sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/is-wsl": {
@@ -14719,6 +14779,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -15742,6 +15807,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.1.tgz",
+      "integrity": "sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -19739,17 +19815,35 @@
         "loader-utils": "^2.0.0"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.8.4.tgz",
+      "integrity": "sha512-rKH8LjZiszWEvmi01NR72QWZ8m4xmXre0OOwlRGnjU01Eqz/QnN+cqpty2PJ0efHblq09+KilvyR7lsbzmXVEw==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
     "@tanstack/query-core": {
-      "version": "4.29.25",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.25.tgz",
-      "integrity": "sha512-DI4y4VC6Uw4wlTpOocEXDky69xeOScME1ezLKsj+hOk7DguC9fkqXtp6Hn39BVb9y0b5IBrY67q6kIX623Zj4Q=="
+      "version": "4.32.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.32.6.tgz",
+      "integrity": "sha512-YVB+mVWENQwPyv+40qO7flMgKZ0uI41Ph7qXC2Zf1ft5AIGfnXnMZyifB2ghhZ27u+5wm5mlzO4Y6lwwadzxCA=="
     },
     "@tanstack/react-query": {
-      "version": "4.29.25",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.25.tgz",
-      "integrity": "sha512-c1+Ezu+XboYrdAMdusK2fTdRqXPMgPAnyoTrzHOZQqr8Hqz6PNvV9DSKl8agUo6nXX4np7fdWabIprt+838dLg==",
+      "version": "4.32.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.32.6.tgz",
+      "integrity": "sha512-AITu/IKJJJXsHHeXNBy5bclu12t08usMCY0vFC2dh9SP/w6JAk5U9GwfjOIPj3p+ATADZvxQPe8UiCtMLNeQbg==",
       "requires": {
-        "@tanstack/query-core": "4.29.25",
+        "@tanstack/query-core": "4.32.6",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.32.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.32.6.tgz",
+      "integrity": "sha512-Gd9pBkm2sbeze9P5Yp8R7y0rZVUdoIOhduomDjz138WdJuVbRS4Y8p6gX2uMJFsUFVe7jA6fX/D6NfQ9o5OS/A==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
         "use-sync-external-store": "^1.2.0"
       }
     },
@@ -21636,6 +21730,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "requires": {
+        "is-what": "^4.1.8"
+      }
     },
     "core-js": {
       "version": "3.29.1",
@@ -24168,6 +24270,11 @@
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "is-what": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.15.tgz",
+      "integrity": "sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA=="
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -27785,6 +27892,11 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -28521,6 +28633,14 @@
       "requires": {
         "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "superjson": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.13.1.tgz",
+      "integrity": "sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==",
+      "requires": {
+        "copy-anything": "^3.0.2"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.3",
     "@tanstack/react-query": "^4.29.25",
+    "@tanstack/react-query-devtools": "^4.32.6",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/API/cartAPI.ts
+++ b/src/API/cartAPI.ts
@@ -1,9 +1,14 @@
 import axios from "axios";
 import { BASE_URL } from "../constant/baseUrl";
-import { CreateCartType } from "../types/Cart.type";
+import { CreateCartType, UpdateCartQuantityType } from "../types/Cart.type";
 
 const cartAPI = {
-  async createCart({ token, product_id, quantity, check }: CreateCartType) {
+  async createCartProduct({
+    token,
+    product_id,
+    quantity,
+    check,
+  }: CreateCartType) {
     const config = {
       headers: {
         Authorization: `JWT ${token}`,
@@ -13,6 +18,36 @@ const cartAPI = {
     const result = await axios.post(`${BASE_URL}/cart/`, data, config);
     // console.log(result.data);
     return result.data;
+  },
+  async fetchCartList(token: string) {
+    const config = {
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    };
+    const result = await axios.get(`${BASE_URL}/cart/`, config);
+    return result.data;
+  },
+  async updateCartQuantity({
+    token,
+    product_id,
+    cart_item_id,
+    quantity,
+    is_active,
+  }: UpdateCartQuantityType) {
+    const config = {
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    };
+    const data = { product_id, quantity, is_active };
+    const quantityResults = await axios.put(
+      `${BASE_URL}/cart/${cart_item_id}/`,
+      data,
+      config
+    );
+    // console.log(quantityResults.data);
+    return quantityResults.data;
   },
 };
 

--- a/src/API/cartAPI.ts
+++ b/src/API/cartAPI.ts
@@ -49,6 +49,20 @@ const cartAPI = {
     // console.log(quantityResults.data);
     return quantityResults.data;
   },
+  async deleteCartItem({
+    token,
+    cart_item_id,
+  }: {
+    token: string;
+    cart_item_id: number;
+  }) {
+    const config = {
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    };
+    await axios.delete(`${BASE_URL}/cart/${cart_item_id}`, config);
+  },
 };
 
 export default cartAPI;

--- a/src/API/cartAPI.ts
+++ b/src/API/cartAPI.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import { BASE_URL } from "../constant/baseUrl";
+import { CreateCartType } from "../types/Cart.type";
+
+const cartAPI = {
+  async createCart({ token, product_id, quantity, check }: CreateCartType) {
+    const config = {
+      headers: {
+        Authorization: `JWT ${token}`,
+      },
+    };
+    const data = { product_id, quantity, check };
+    const result = await axios.post(`${BASE_URL}/cart/`, data, config);
+    // console.log(result.data);
+    return result.data;
+  },
+};
+
+export default cartAPI;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { store } from "./store/store";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Suspense } from "react";
 import Loading from "./components/common/Loading/Loading";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -25,6 +26,7 @@ function App() {
           <ThemeProvider theme={theme}>
             <GlobalStyle />
             <Router />
+            <ReactQueryDevtools />
           </ThemeProvider>
         </Provider>
       </QueryClientProvider>

--- a/src/Pages/CartPage/CartPage.tsx
+++ b/src/Pages/CartPage/CartPage.tsx
@@ -2,58 +2,23 @@ import { useState, useEffect } from "react";
 import CartItem from "../../components/cart/CartItem/CartItem";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import * as S from "./style";
-import {
-  checkAllItem,
-  fetchGetCartList,
-  fetchGetProductDetail,
-} from "../../features/cartListSlice";
+import { checkAllItem } from "../../features/cartListSlice";
 import { RootState } from "../../store/store";
-import Spinner from "../../components/common/Spinner/Spinner";
 import TotalPrice from "../../components/cart/TotalPrice/TotalPrice";
 import CheckCircleBtn from "../../components/common/CheckBtn/CheckCircleBtn";
+import { CartItemType } from "../../types/Cart.type";
+import useFetchCartItems from "../../hooks/queries/useFetchCartItems";
 
 function CartPage() {
   const dispatch = useAppDispatch();
-  const TOKEN = useAppSelector((state: RootState) => state.login.token) || "";
-  const cartItems = useAppSelector(
-    (state: RootState) => state.cartList.cartItems
-  );
-  // console.log(cartItems);
-  const cartStatus = useAppSelector(
-    (state: RootState) => state.cartList.status
-  );
+  const token = useAppSelector((state: RootState) => state.login.token) || "";
 
   const areAllItemsChecked = useAppSelector((state) =>
     state.cartList.cartItems.every((item) => item.isChecked)
   );
 
   // 장바구니 정보 가져오기
-  useEffect(() => {
-    if (TOKEN) {
-      dispatch(fetchGetCartList(TOKEN));
-    }
-  }, [TOKEN, dispatch]);
-
-  // 상품 상세 정보 가져오기
-  useEffect(() => {
-    const getProductDetails = async () => {
-      for (const cartItem of cartItems) {
-        // 이미 상품 상세 정보를 가져온 경우는 제외
-        if (cartItem.item) {
-          continue;
-        }
-        dispatch(fetchGetProductDetail(cartItem.product_id));
-      }
-    };
-
-    if (cartItems.length > 0) {
-      getProductDetails();
-    }
-  }, [cartItems, dispatch]);
-
-  if (cartStatus === "loading") {
-    return <Spinner />;
-  }
+  let { cartItems } = useFetchCartItems(token);
 
   return (
     <S.CartPageLayout>
@@ -67,11 +32,12 @@ function CartPage() {
         <li>수량</li>
         <li>상품금액</li>
       </S.MenuUl>
-      {cartItems.map((cartItem) => (
+      {cartItems.map((cartItem: CartItemType) => (
         <CartItem
           key={cartItem.cart_item_id}
+          cartItemId={cartItem.cart_item_id}
           quantity={cartItem.quantity}
-          cartItem={cartItem}
+          cartItem={cartItem.productDetail}
         />
       ))}
       {cartItems.length === 0 ? (

--- a/src/Pages/CartPage/CartPage.tsx
+++ b/src/Pages/CartPage/CartPage.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import CartItem from "../../components/cart/CartItem/CartItem";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import * as S from "./style";
@@ -18,7 +17,7 @@ function CartPage() {
   );
 
   // 장바구니 정보 가져오기
-  let { cartItems } = useFetchCartItems(token);
+  const { cartItems } = useFetchCartItems(token);
 
   return (
     <S.CartPageLayout>

--- a/src/Pages/ProductDetailPage/ProductDetailPage.tsx
+++ b/src/Pages/ProductDetailPage/ProductDetailPage.tsx
@@ -23,7 +23,7 @@ function ProductDetailPage() {
 
   const { data } = useFetchProductDetail(productIdValue);
 
-  const cartMutation = useMutation(cartAPI.createCart, {
+  const cartMutation = useMutation(cartAPI.createCartProduct, {
     onSuccess: () => {
       navigate("/cart");
     },

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -3,10 +3,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import AmountBtn from "../../common/AmountBtn/AmountBtn";
 import Button from "../../common/Button/Button";
 import Modal from "../../common/Modal/Modal";
-import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { useAppSelector } from "../../../store/hooks";
 import { RootState } from "../../../store/store";
 import * as S from "./style";
-import { openModal } from "../../../features/modalSlice";
 import { ProductDetailType } from "../../../types/Cart.type";
 import cartAPI from "../../../API/cartAPI";
 // import CheckCircleBtn from "../../common/CheckBtn/CheckCircleBtn";
@@ -18,16 +17,10 @@ interface CartItemProps {
 }
 
 function CartItem({ cartItem, quantity, cartItemId }: CartItemProps) {
-  const dispatch = useAppDispatch();
   const token = useAppSelector((state: RootState) => state.login.token) || "";
-  const modal = useAppSelector((state: RootState) => state.modal.isOpen);
-  console.log(modal);
+  const [isOpenModal, setIsOpenModal] = useState(false);
   const [count, setCount] = useState(quantity);
   const queryClient = useQueryClient();
-
-  const handleOpenDeleteModal = () => {
-    dispatch(openModal());
-  };
 
   const deleteCartItemMutation = useMutation(cartAPI.deleteCartItem, {
     onMutate: async (data) => {
@@ -57,12 +50,19 @@ function CartItem({ cartItem, quantity, cartItemId }: CartItemProps) {
     },
   });
 
+  const handleOpenDeleteModal = () => {
+    setIsOpenModal(true);
+    console.log("클릭된값", cartItemId);
+  };
+
   const handleConfirmDelete = () => {
     const data = {
       token: token,
       cart_item_id: cartItemId,
     };
+    // console.log("삭제되는 값", data.cart_item_id);
     deleteCartItemMutation.mutate(data);
+    setIsOpenModal(false);
   };
 
   // const handleCheckboxToggle = () => {
@@ -70,8 +70,18 @@ function CartItem({ cartItem, quantity, cartItemId }: CartItemProps) {
   // };
   return (
     <S.ProductList>
-      {modal && (
-        <Modal onClickYes={handleConfirmDelete}>삭제하시겠습니까?</Modal>
+      {isOpenModal && (
+        <Modal
+          onClickYes={handleConfirmDelete}
+          onClickNo={() => {
+            setIsOpenModal(false);
+          }}
+          onClickOutside={() => {
+            setIsOpenModal(false);
+          }}
+        >
+          삭제하시겠습니까?
+        </Modal>
       )}
       {/* <CheckCircleBtn
         isChecked={cartItem.isChecked}

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -21,6 +21,7 @@ function CartItem({ cartItem, quantity, cartItemId }: CartItemProps) {
   const dispatch = useAppDispatch();
   const token = useAppSelector((state: RootState) => state.login.token) || "";
   const modal = useAppSelector((state: RootState) => state.modal.isOpen);
+  console.log(modal);
   const [count, setCount] = useState(quantity);
   const queryClient = useQueryClient();
 

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -3,23 +3,20 @@ import { useState } from "react";
 import AmountBtn from "../../common/AmountBtn/AmountBtn";
 import Button from "../../common/Button/Button";
 import Modal from "../../common/Modal/Modal";
-import {
-  CartItems,
-  checkItem,
-  fetchDeleteProduct,
-} from "../../../features/cartListSlice";
+import { fetchDeleteProduct } from "../../../features/cartListSlice";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import { RootState } from "../../../store/store";
 import * as S from "./style";
 import { openModal } from "../../../features/modalSlice";
-import CheckCircleBtn from "../../common/CheckBtn/CheckCircleBtn";
+import { ProductDetailType } from "../../../types/Cart.type";
 
 interface CartItemProps {
-  cartItem: CartItems;
+  cartItem: ProductDetailType;
   quantity: number;
+  cartItemId: number;
 }
 
-function CartItem({ cartItem, quantity }: CartItemProps) {
+function CartItem({ cartItem, quantity, cartItemId }: CartItemProps) {
   const dispatch = useAppDispatch();
   const TOKEN = useAppSelector((state: RootState) => state.login.token) || "";
   const modal = useAppSelector((state: RootState) => state.modal.isOpen);
@@ -30,38 +27,33 @@ function CartItem({ cartItem, quantity }: CartItemProps) {
   };
 
   const handleConfirmDelete = () => {
-    dispatch(
-      fetchDeleteProduct({ TOKEN, cart_item_id: cartItem.cart_item_id })
-    );
+    dispatch(fetchDeleteProduct({ TOKEN, cart_item_id: cartItemId }));
   };
 
-  const handleCheckboxToggle = () => {
-    dispatch(checkItem({ product_id: cartItem.product_id }));
-  };
+  // const handleCheckboxToggle = () => {
+  //   dispatch(checkItem({ product_id: cartItem.product_id }));
+  // };
   return (
     <S.ProductList>
       {modal && (
         <Modal onClickYes={handleConfirmDelete}>삭제하시겠습니까?</Modal>
       )}
-      <CheckCircleBtn
+      {/* <CheckCircleBtn
         isChecked={cartItem.isChecked}
         onChange={handleCheckboxToggle}
-      />
+      /> */}
       <S.ProductInfoBox>
-        <img src={cartItem.item?.image} alt="상품이미지" />
+        <img src={cartItem.image} alt="상품이미지" />
         <div>
-          <S.ShopText>{cartItem.item?.store_name}</S.ShopText>
-          <S.ProductNameTxt>{cartItem.item?.product_name}</S.ProductNameTxt>
+          <S.ShopText>{cartItem.store_name}</S.ShopText>
+          <S.ProductNameTxt>{cartItem.product_name}</S.ProductNameTxt>
           <S.ProductPriceTxt>
-            {cartItem.item?.price.toLocaleString()}원
+            {cartItem.price.toLocaleString()}원
           </S.ProductPriceTxt>
           <S.ShipText>
-            {cartItem.item?.shipping_method === "PARCEL"
-              ? "직접배송"
-              : "택배배송"}{" "}
-            /
-            {cartItem.item?.shipping_fee
-              ? `${cartItem.item?.shipping_fee.toLocaleString()}원`
+            {cartItem.shipping_method === "PARCEL" ? "직접배송" : "택배배송"} /
+            {cartItem.shipping_fee
+              ? `${cartItem.shipping_fee.toLocaleString()}원`
               : "무료배송"}
           </S.ShipText>
         </div>
@@ -69,18 +61,14 @@ function CartItem({ cartItem, quantity }: CartItemProps) {
       <AmountBtn
         count={count}
         setCount={setCount}
-        stock={cartItem.item?.stock}
-        productId={cartItem.item?.product_id}
-        cartId={cartItem.cart_item_id}
+        stock={cartItem.stock}
+        productId={cartItem.product_id}
+        cartId={cartItemId}
       />
       <S.TotalPriceWrapper>
         <S.TotalPriceTxt>
-          {cartItem.item?.price !== undefined &&
-          cartItem.item?.shipping_fee !== undefined
-            ? (
-                cartItem.item?.price * count +
-                cartItem.item?.shipping_fee
-              ).toLocaleString()
+          {cartItem.price !== undefined && cartItem.shipping_fee !== undefined
+            ? (cartItem.price * count + cartItem.shipping_fee).toLocaleString()
             : "가격 정보 없음"}{" "}
           원
         </S.TotalPriceTxt>

--- a/src/components/common/AmountBtn/AmountBtn.tsx
+++ b/src/components/common/AmountBtn/AmountBtn.tsx
@@ -7,7 +7,7 @@ interface AmountBtnProps {
   count: number;
   setCount: React.Dispatch<React.SetStateAction<number>>;
   stock?: number;
-  productId?: number;
+  productId?: string;
   cartId?: number;
 }
 
@@ -24,34 +24,34 @@ function AmountBtn({
   const handleDecrease = () => {
     if (count > 1) {
       setCount(count - 1);
-      if (productId !== undefined && cartId !== undefined) {
-        dispatch(
-          fetchModifyCartQuantity({
-            TOKEN: token,
-            product_id: productId,
-            cart_item_id: cartId,
-            quantity: count - 1,
-            is_active: true,
-          })
-        );
-      }
+    }
+    if (productId !== undefined && cartId !== undefined) {
+      dispatch(
+        fetchModifyCartQuantity({
+          TOKEN: token,
+          product_id: productId,
+          cart_item_id: cartId,
+          quantity: count - 1,
+          is_active: true,
+        })
+      );
     }
   };
 
   const handleIncrease = () => {
     if (stock !== undefined && count < stock) {
       setCount(count + 1);
-      if (productId !== undefined && cartId !== undefined) {
-        dispatch(
-          fetchModifyCartQuantity({
-            TOKEN: token,
-            product_id: productId,
-            cart_item_id: cartId,
-            quantity: count + 1,
-            is_active: true,
-          })
-        );
-      }
+    }
+    if (productId !== undefined && cartId !== undefined) {
+      dispatch(
+        fetchModifyCartQuantity({
+          TOKEN: token,
+          product_id: productId,
+          cart_item_id: cartId,
+          quantity: count + 1,
+          is_active: true,
+        })
+      );
     }
   };
 

--- a/src/components/common/AmountBtn/AmountBtn.tsx
+++ b/src/components/common/AmountBtn/AmountBtn.tsx
@@ -1,7 +1,8 @@
-import { useAppDispatch, useAppSelector } from "../../../store/hooks";
+import { useAppSelector } from "../../../store/hooks";
 import { RootState } from "../../../store/store";
-import { fetchModifyCartQuantity } from "../../../features/cartListSlice";
 import * as S from "./style";
+import { useMutation } from "@tanstack/react-query";
+import cartAPI from "../../../API/cartAPI";
 
 interface AmountBtnProps {
   count: number;
@@ -18,23 +19,25 @@ function AmountBtn({
   productId,
   cartId,
 }: AmountBtnProps) {
-  const dispatch = useAppDispatch();
   const token = useAppSelector((state: RootState) => state.login.token) || "";
+
+  const updateQuantityMutation = useMutation(cartAPI.updateCartQuantity, {
+    onSuccess: () => {},
+  });
 
   const handleDecrease = () => {
     if (count > 1) {
       setCount(count - 1);
     }
     if (productId !== undefined && cartId !== undefined) {
-      dispatch(
-        fetchModifyCartQuantity({
-          TOKEN: token,
-          product_id: productId,
-          cart_item_id: cartId,
-          quantity: count - 1,
-          is_active: true,
-        })
-      );
+      const quantityData = {
+        token: token,
+        product_id: productId,
+        cart_item_id: cartId,
+        quantity: count - 1,
+        is_active: true,
+      };
+      updateQuantityMutation.mutate(quantityData);
     }
   };
 
@@ -43,15 +46,14 @@ function AmountBtn({
       setCount(count + 1);
     }
     if (productId !== undefined && cartId !== undefined) {
-      dispatch(
-        fetchModifyCartQuantity({
-          TOKEN: token,
-          product_id: productId,
-          cart_item_id: cartId,
-          quantity: count + 1,
-          is_active: true,
-        })
-      );
+      const quantityData = {
+        token: token,
+        product_id: productId,
+        cart_item_id: cartId,
+        quantity: count + 1,
+        is_active: true,
+      };
+      updateQuantityMutation.mutate(quantityData);
     }
   };
 

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,5 +1,4 @@
 import { useRef } from "react";
-import { useNavigate } from "react-router-dom";
 import * as S from "./style";
 import { useAppDispatch } from "../../../store/hooks";
 import { closeModal } from "../../../features/modalSlice";

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -6,21 +6,38 @@ import { closeModal } from "../../../features/modalSlice";
 interface ModalProps {
   children: React.ReactNode;
   onClickYes: () => void;
+  onClickNo?: () => void;
+  onClickOutside?: () => void;
 }
 
-function Modal({ children, onClickYes }: ModalProps) {
+function Modal({
+  children,
+  onClickYes,
+  onClickNo,
+  onClickOutside,
+}: ModalProps) {
   const backgroundRef = useRef() as React.MutableRefObject<HTMLInputElement>;
   const dispatch = useAppDispatch();
 
   // 배경화면 클릭시 모달창 닫기
   const handleClickOutside = (e: React.MouseEvent<HTMLElement>) => {
     if (backgroundRef.current === e.target) {
+      if (onClickOutside) {
+        onClickOutside();
+      }
       dispatch(closeModal());
     }
   };
 
   const handleYesBtn = () => {
     onClickYes();
+    dispatch(closeModal());
+  };
+
+  const handleNoBtn = () => {
+    if (onClickNo) {
+      onClickNo();
+    }
     dispatch(closeModal());
   };
 
@@ -33,9 +50,7 @@ function Modal({ children, onClickYes }: ModalProps) {
             type="button"
             size="s"
             color="white"
-            onClick={() => {
-              dispatch(closeModal());
-            }}
+            onClick={handleNoBtn}
           >
             아니오
           </S.ModalBtn>

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -62,6 +62,46 @@ function Navbar() {
     </Modal>
   );
 
+  // userType === "BUYER" /토큰이 없을때 guest Header
+  const buyerHeader = (
+    <S.HeaderUserWrapper>
+      <S.CartBtn
+        type="button"
+        aria-label="장바구니에 담기 버튼"
+        onClick={
+          token
+            ? () => navigate("/cart")
+            : () => {
+                dispatch(openModal());
+              }
+        }
+      >
+        <img src={CartIcon} alt="장바구니 아이콘버튼" />
+        <S.CartText>장바구니</S.CartText>
+      </S.CartBtn>
+
+      <S.UserBtn onClick={handleUserClick}>
+        <img src={UserIcon} alt="유저 아이콘 버튼" />
+        <S.UserText>{token ? "마이페이지" : "로그인"}</S.UserText>
+        {token && dropDown && <DropDown />}
+      </S.UserBtn>
+    </S.HeaderUserWrapper>
+  );
+
+  // userType === "SELLER"
+  const sellerHeader = (
+    <S.HeaderUserWrapper>
+      <S.UserBtn onClick={handleUserClick}>
+        <img src={UserIcon} alt="유저 아이콘 버튼" />
+        <S.UserText>마이페이지</S.UserText>
+        {token && dropDown && <DropDown />}
+      </S.UserBtn>
+      <S.ShoppingBagBtn type="button" size="ms" onClick={handleMoveToAdminPage}>
+        판매자센터
+      </S.ShoppingBagBtn>
+    </S.HeaderUserWrapper>
+  );
+
   return (
     <S.HomeHeader>
       {!token && modal ? needLoginModal : null}
@@ -87,45 +127,11 @@ function Navbar() {
             />
           </S.SearchBarWrapper>
         </S.HeaderSearchWrapper>
-        {userType === "BUYER" ? (
-          <S.HeaderUserWrapper>
-            <S.CartBtn
-              type="button"
-              aria-label="장바구니에 담기 버튼"
-              onClick={
-                token
-                  ? () => navigate("/cart")
-                  : () => {
-                      dispatch(openModal());
-                    }
-              }
-            >
-              <img src={CartIcon} alt="장바구니 아이콘버튼" />
-              <S.CartText>장바구니</S.CartText>
-            </S.CartBtn>
-
-            <S.UserBtn onClick={handleUserClick}>
-              <img src={UserIcon} alt="유저 아이콘 버튼" />
-              <S.UserText>{token ? "마이페이지" : "로그인"}</S.UserText>
-              {token && dropDown && <DropDown />}
-            </S.UserBtn>
-          </S.HeaderUserWrapper>
-        ) : (
-          <S.HeaderUserWrapper>
-            <S.UserBtn onClick={handleUserClick}>
-              <img src={UserIcon} alt="유저 아이콘 버튼" />
-              <S.UserText>마이페이지</S.UserText>
-              {token && dropDown && <DropDown />}
-            </S.UserBtn>
-            <S.ShoppingBagBtn
-              type="button"
-              size="ms"
-              onClick={handleMoveToAdminPage}
-            >
-              판매자센터
-            </S.ShoppingBagBtn>
-          </S.HeaderUserWrapper>
-        )}
+        {userType === "BUYER"
+          ? buyerHeader
+          : token
+          ? sellerHeader
+          : buyerHeader}
       </S.Navbar>
     </S.HomeHeader>
   );

--- a/src/features/cartListSlice.ts
+++ b/src/features/cartListSlice.ts
@@ -35,7 +35,7 @@ interface CartListState {
 
 interface ModifiedQuantity {
   TOKEN: string;
-  product_id: number;
+  product_id: string;
   cart_item_id: number;
   quantity: number;
   is_active: Boolean;
@@ -211,10 +211,6 @@ const cartSlice = createSlice({
           item: null, // 초기에는 item을 null로 설정합니다.
           isChecked: true, // 초기 장바구니 담겨질때는 각 아이템 체크박스 true로 설정
         }));
-      })
-      .addCase(fetchGetCartList.rejected, (state, action) => {
-        state.status = "failed";
-        state.error = action.error.message || "Something was wrong";
       })
       .addCase(fetchGetProductDetail.fulfilled, (state, action) => {
         const productId = action.payload.product_id; // product_id 속성 사용

--- a/src/features/cartListSlice.ts
+++ b/src/features/cartListSlice.ts
@@ -1,6 +1,4 @@
-import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import axios from "axios";
-import { BASE_URL } from "../constant/baseUrl";
+import { createSlice } from "@reduxjs/toolkit";
 
 export interface Item {
   image: string;
@@ -33,14 +31,6 @@ interface CartListState {
   error: string;
 }
 
-interface ModifiedQuantity {
-  TOKEN: string;
-  product_id: string;
-  cart_item_id: number;
-  quantity: number;
-  is_active: Boolean;
-}
-
 const initialState: CartListState = {
   status: "idle",
   cartItems: [],
@@ -48,94 +38,6 @@ const initialState: CartListState = {
   deliveryPrice: 0,
   error: "",
 };
-
-// 장바구니 상품 정보 가져오기
-export const fetchGetCartList = createAsyncThunk(
-  "cartList/fetchGetCartList",
-  async (TOKEN: string) => {
-    try {
-      const config = {
-        headers: {
-          Authorization: `JWT ${TOKEN}`,
-        },
-      };
-      const result = await axios.get(`${BASE_URL}/cart/`, config);
-      // console.log(result.data);
-      return result.data;
-    } catch (error: any) {
-      console.log(error);
-    }
-  }
-);
-
-// 상세 상품 정보 가져오기
-export const fetchGetProductDetail = createAsyncThunk(
-  "products/fetchGetProductDetail",
-  async (product_id: number) => {
-    try {
-      const detailResults = await axios.get(
-        `${BASE_URL}/products/${product_id}`
-      );
-      // console.log(detailResults.data);
-      return detailResults.data;
-    } catch (error: any) {
-      console.log(error);
-    }
-  }
-);
-
-// 장바구니 수량 변경
-export const fetchModifyCartQuantity = createAsyncThunk(
-  "cartList/fetchModifyCartQuantity",
-  async ({
-    TOKEN,
-    product_id,
-    cart_item_id,
-    quantity,
-    is_active,
-  }: ModifiedQuantity) => {
-    try {
-      const config = {
-        headers: {
-          Authorization: `JWT ${TOKEN}`,
-        },
-      };
-      const data = { product_id, quantity, is_active };
-      const quantityResults = await axios.put(
-        `${BASE_URL}/cart/${cart_item_id}/`,
-        data,
-        config
-      );
-      // console.log(quantityResults.data);
-      return quantityResults.data;
-    } catch (error: any) {
-      console.log(error);
-    }
-  }
-);
-
-// 장바구니 아이템 삭제하기
-export const fetchDeleteProduct = createAsyncThunk(
-  "cartList/fetchDeleteProduct",
-  async ({ TOKEN, cart_item_id }: { TOKEN: string; cart_item_id: number }) => {
-    try {
-      const config = {
-        headers: {
-          Authorization: `JWT ${TOKEN}`,
-        },
-      };
-      const deleteResults = await axios.delete(
-        `${BASE_URL}/cart/${cart_item_id}`,
-        config
-      );
-      console.log(deleteResults);
-      // return deleteResults;
-      return deleteResults.status;
-    } catch (error: any) {
-      console.log(error);
-    }
-  }
-);
 
 const cartSlice = createSlice({
   name: "cartList",
@@ -197,91 +99,6 @@ const cartSlice = createSlice({
         });
       }
     },
-  },
-  extraReducers: (builder) => {
-    builder
-      .addCase(fetchGetCartList.pending, (state) => {
-        state.status = "loading";
-        state.error = "";
-      })
-      .addCase(fetchGetCartList.fulfilled, (state, action) => {
-        state.status = "succeeded";
-        state.cartItems = action.payload.results.map((cartItem: CartItems) => ({
-          ...cartItem,
-          item: null, // 초기에는 item을 null로 설정합니다.
-          isChecked: true, // 초기 장바구니 담겨질때는 각 아이템 체크박스 true로 설정
-        }));
-      })
-      .addCase(fetchGetProductDetail.fulfilled, (state, action) => {
-        const productId = action.payload.product_id; // product_id 속성 사용
-        const cartItem = state.cartItems.find(
-          (item) => item.product_id === productId
-        ); //기존 cartItem 의 product_id 와 fetchGetProductDetail 의 파라미터 product_id 와 비교해서 같은거일때 cartItem 의 item 값에 추가
-        if (cartItem) {
-          cartItem.item = action.payload;
-        }
-        // 총 상품 금액 초기화
-        state.selectedTotalPrice = state.cartItems.reduce(
-          (totalPrice, cartItem) => {
-            if (cartItem.isChecked && cartItem.item) {
-              totalPrice += cartItem.item.price * cartItem.quantity;
-            }
-            return totalPrice;
-          },
-          0
-        );
-        // 배송비 초기화
-        state.deliveryPrice = state.cartItems.reduce(
-          (totalShippingFee, cartItem) => {
-            if (cartItem.isChecked && cartItem.item) {
-              totalShippingFee += cartItem.item.shipping_fee;
-            }
-            return totalShippingFee;
-          },
-          0
-        );
-      })
-      //장바구니 수량 수정
-      .addCase(fetchModifyCartQuantity.fulfilled, (state, action) => {
-        const { product_id, quantity } = action.payload;
-        const cartItem = state.cartItems.find(
-          (item) => item.product_id === product_id
-        );
-        if (cartItem) {
-          // 총 상품 금액 재계산
-          const priceDiff =
-            (quantity - cartItem.quantity) * (cartItem.item?.price || 0);
-          cartItem.quantity = quantity;
-          if (cartItem.isChecked) {
-            state.selectedTotalPrice += priceDiff;
-          }
-        }
-      })
-      .addCase(fetchDeleteProduct.fulfilled, (state, action) => {
-        const { cart_item_id } = action.meta.arg; //fetchDeleteProduct 의 매개변수에 접근 가능함
-        const index = state.cartItems.findIndex(
-          (item) => item.cart_item_id === cart_item_id
-        );
-        if (index > -1) {
-          // 총 상품금액 재계산
-          const deletedCartItem = state.cartItems[index];
-          if (deletedCartItem.isChecked && deletedCartItem.item) {
-            state.selectedTotalPrice -=
-              deletedCartItem.item.price * deletedCartItem.quantity;
-          }
-          state.cartItems.splice(index, 1);
-        }
-        // 배송비 재계산
-        state.deliveryPrice = state.cartItems.reduce(
-          (totalShippingFee, cartItem) => {
-            if (cartItem.isChecked && cartItem.item) {
-              totalShippingFee += cartItem.item.shipping_fee;
-            }
-            return totalShippingFee;
-          },
-          0
-        );
-      });
   },
 });
 

--- a/src/features/postCartSlice.ts
+++ b/src/features/postCartSlice.ts
@@ -1,6 +1,4 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import axios from "axios";
-import { BASE_URL } from "../constant/baseUrl";
 
 interface CartItem {
   my_cart?: number;
@@ -15,55 +13,16 @@ interface CartSliceProps {
   error: string;
 }
 
-interface PostCartType {
-  TOKEN: string;
-  product_id: number;
-  quantity: number;
-  check: boolean;
-}
-
 const initialState: CartSliceProps = {
   item: {},
   status: "idle",
   error: "",
 };
 
-export const fetchPostCart = createAsyncThunk(
-  "cart/fetchPostCart",
-  async ({ TOKEN, product_id, quantity, check }: PostCartType) => {
-    try {
-      const config = {
-        headers: {
-          Authorization: `JWT ${TOKEN}`,
-        },
-      };
-      const data = { product_id, quantity, check };
-      const result = await axios.post(`${BASE_URL}/cart/`, data, config);
-      // console.log(result.data);
-      return result.data;
-    } catch (error: any) {
-      console.log(error);
-    }
-  }
-);
-
 export const postCartSlice = createSlice({
   name: "cart",
   initialState,
   reducers: {},
-  extraReducers: (builder) => {
-    builder
-      .addCase(fetchPostCart.fulfilled, (state, action) => {
-        state.item = action.payload;
-        state.status = "succeeded";
-        state.error = "";
-      })
-      .addCase(fetchPostCart.rejected, (state, action) => {
-        state.status = "failed";
-        state.error = action.error.message || "Something is wrong";
-        state.item = {};
-      });
-  },
 });
 
 export default postCartSlice.reducer;

--- a/src/hooks/queries/useFetchCartItems.tsx
+++ b/src/hooks/queries/useFetchCartItems.tsx
@@ -1,0 +1,36 @@
+import { useQueries } from "@tanstack/react-query";
+import productAPI from "../../API/productAPI";
+import useFetchCartList from "./useFetchCartList";
+import { CartType } from "../../types/Cart.type";
+
+const useFetchCartItems = (token: string) => {
+  // CartList 가져오기
+  const { data: cartList } = useFetchCartList(token);
+  // console.log(cartList);
+
+  const productIds = cartList.results.map((item: any) => {
+    return item.product_id;
+  });
+
+  // console.log("Product IDs:", productIds);
+
+  const queryInput = productIds.map((productId: string) => {
+    return {
+      queryKey: ["cartProductDetail", productId],
+      queryFn: () => productAPI.fetchProductDetail(productId),
+    };
+  });
+  // console.log("Query Input:", queryInput);
+
+  const cartItemsResponses = useQueries({ queries: queryInput });
+
+  // 결과를 기반으로 cartItems 생성
+  const cartItems = cartList?.results?.map((item: CartType, index: any) => ({
+    ...item,
+    productDetail: cartItemsResponses[index]?.data,
+  }));
+
+  return { cartItems };
+};
+
+export default useFetchCartItems;

--- a/src/hooks/queries/useFetchCartItems.tsx
+++ b/src/hooks/queries/useFetchCartItems.tsx
@@ -4,7 +4,6 @@ import useFetchCartList from "./useFetchCartList";
 import { CartType } from "../../types/Cart.type";
 
 const useFetchCartItems = (token: string) => {
-  // CartList 가져오기
   const { data: cartList } = useFetchCartList(token);
   // console.log(cartList);
 

--- a/src/hooks/queries/useFetchCartList.tsx
+++ b/src/hooks/queries/useFetchCartList.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import cartAPI from "../../API/cartAPI";
+
+export const useFetchCartList = (token: string) => {
+  return useQuery(
+    ["CartList", token],
+    () => {
+      return cartAPI.fetchCartList(token);
+    },
+    { suspense: true }
+  );
+};
+
+export default useFetchCartList;

--- a/src/hooks/queries/useFetchCartList.tsx
+++ b/src/hooks/queries/useFetchCartList.tsx
@@ -3,7 +3,7 @@ import cartAPI from "../../API/cartAPI";
 
 export const useFetchCartList = (token: string) => {
   return useQuery(
-    ["CartList", token],
+    ["cartList", token],
     () => {
       return cartAPI.fetchCartList(token);
     },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );

--- a/src/types/Cart.type.ts
+++ b/src/types/Cart.type.ts
@@ -11,3 +11,30 @@ export interface UpdateCartQuantityType {
   quantity: number;
   is_active: boolean;
 }
+
+export interface CartType {
+  my_cart: number;
+  cart_item_id: number;
+  product_id: string;
+  quantity: number;
+  is_active: boolean;
+}
+
+export interface CartItemType extends CartType {
+  productDetail: ProductDetailType;
+}
+
+export interface ProductDetailType {
+  product_id: string;
+  created_at: string;
+  updated_at: string;
+  product_name: string;
+  image: string;
+  price: number;
+  shipping_method: "PARCEL" | "DELIVERY"; //string, 선택
+  shipping_fee: number;
+  stock: number;
+  products_info: string;
+  seller: string;
+  store_name: string;
+}

--- a/src/types/Cart.type.ts
+++ b/src/types/Cart.type.ts
@@ -4,3 +4,10 @@ export interface CreateCartType {
   quantity: number;
   check: boolean;
 }
+export interface UpdateCartQuantityType {
+  token: string;
+  product_id: string;
+  cart_item_id: number;
+  quantity: number;
+  is_active: boolean;
+}

--- a/src/types/Cart.type.ts
+++ b/src/types/Cart.type.ts
@@ -1,0 +1,6 @@
+export interface CreateCartType {
+  token: string;
+  product_id: string;
+  quantity: number;
+  check: boolean;
+}


### PR DESCRIPTION
## 🔶작업사항
- 밑에 커밋사항 참고
- <fix> : cartItem 전역상태 모달 제거 후 각 cartItem 안에서 로컬상태 모달 기능 추가

## 🔶변경로직
-기존에는 CartItem.tsx 에서 redux-toolkit 으로 관리되는 전역상태의 모달을 import 해와서 사용했었음. 이에 따라 각 장바구니 아이템의 삭제버튼 클릭시, 각각의 CartItem 컴포넌트가 하나의 모달의 상태로 취급되어 모달의 상태변경(true,false)가 제대로 반영되지 않았음. 더불어, 삭제 버튼을 클릭해서 모달이 true였을때의 cartItemId와 모달이 열린 후 예 버튼을 눌렀을때 cartItem 값이 달라서, 막상 실제 클릭한 장바구니 아이템이 아닌 쌩뚱맞은 cartItemId 배열의 맨 마지막 아이템이 삭제되는 문제점이 발생했다.  

ex)
let cartItemId =[2000,2001,20002] 라고 했을 때 2000번 아이템을 클릭했는데 2002번이 삭제되는 상황 발생

-CartPage.tsx 부모 컴포넌트에서 데이터를 받아서 CartItem 으로 map 을 돌리는 상황이기에 모달은 각 로컬 상태에서 관리되어야한다. 여러 CartItem 컴포넌트가 동시에 모달을 열려고 시도하면, 여러 CartItem 들이 모달 상태를 변경하면서 발생하는 경쟁상태 때문에 예상치 못한 결과가 발생할 수 있다. 따라서, CartItem 컴포넌트에서는 모달을 전역이 아닌 로컬상태에서 관리하도록 했다. 각 CartItem 을 독립적으로 모달상태 관리를 하게했다. 

