### PR TITLE
<fix> : 장바구니 버그 해결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ const queryClient = new QueryClient({
 
 function App() {
   return (
-    <Suspense fallback={<Loading />}>
+    <Suspense>
       <QueryClientProvider client={queryClient}>
         <Provider store={store}>
           <ThemeProvider theme={theme}>

--- a/src/Pages/CartPage/CartPage.tsx
+++ b/src/Pages/CartPage/CartPage.tsx
@@ -8,6 +8,7 @@ import CheckCircleBtn from "../../components/common/CheckBtn/CheckCircleBtn";
 import { CartItemType } from "../../types/Cart.type";
 import useFetchCartItems from "../../hooks/queries/useFetchCartItems";
 import { setPaymentAmount } from "../../features/paymentAmountSlice";
+import Loading from "../../components/common/Loading/Loading";
 
 function CartPage() {
   const dispatch = useAppDispatch();
@@ -109,24 +110,26 @@ function CartPage() {
         <li>수량</li>
         <li>상품금액</li>
       </S.MenuUl>
-      {cartItems.map((cartItem: CartItemType, index: number) => (
-        <CartItem
-          key={cartItem.cart_item_id}
-          cartItemId={cartItem.cart_item_id}
-          quantity={cartItem.quantity}
-          cartItem={cartItem.productDetail}
-          isChecked={isCheckedArray[index]}
-          onToggle={() => handleToggleCheckbox(index)}
-        />
-      ))}
-      {cartItems.length === 0 ? (
-        <S.NoItemBox>
-          <p>장바구니에 담긴 상품이 없습니다.</p>
-          <small>원하는 상품을 장바구니에 담아보세요!</small>
-        </S.NoItemBox>
-      ) : (
-        <TotalPrice />
-      )}
+      <Suspense fallback={<Loading />}>
+        {cartItems.map((cartItem: CartItemType, index: number) => (
+          <CartItem
+            key={cartItem.cart_item_id}
+            cartItemId={cartItem.cart_item_id}
+            quantity={cartItem.quantity}
+            cartItem={cartItem.productDetail}
+            isChecked={isCheckedArray[index]}
+            onToggle={() => handleToggleCheckbox(index)}
+          />
+        ))}
+        {cartItems.length === 0 ? (
+          <S.NoItemBox>
+            <p>장바구니에 담긴 상품이 없습니다.</p>
+            <small>원하는 상품을 장바구니에 담아보세요!</small>
+          </S.NoItemBox>
+        ) : (
+          <TotalPrice />
+        )}
+      </Suspense>
     </S.CartPageLayout>
   );
 }

--- a/src/Pages/CartPage/CartPage.tsx
+++ b/src/Pages/CartPage/CartPage.tsx
@@ -32,9 +32,20 @@ function CartPage() {
   );
 
   //체크박스 로직
-  const [isCheckedArray, setIsCheckedArray] = useState(
+  const [isCheckedArray, setIsCheckedArray] = useState(() =>
     new Array(cartItems.length).fill(true)
   );
+
+  useEffect(() => {
+    const diffLength = cartItems.length - isCheckedArray.length;
+    if (diffLength > 0) {
+      setIsCheckedArray((prev) => [
+        ...prev,
+        ...new Array(diffLength).fill(true),
+      ]);
+    }
+  }, [cartItems]);
+
   const [isAllChecked, setIsAllChecked] = useState(true);
 
   // 각 개별 아이템 체크박스 토글
@@ -121,15 +132,15 @@ function CartPage() {
             onToggle={() => handleToggleCheckbox(index)}
           />
         ))}
-        {cartItems.length === 0 ? (
-          <S.NoItemBox>
-            <p>장바구니에 담긴 상품이 없습니다.</p>
-            <small>원하는 상품을 장바구니에 담아보세요!</small>
-          </S.NoItemBox>
-        ) : (
-          <TotalPrice />
-        )}
       </Suspense>
+      {cartItems.length === 0 ? (
+        <S.NoItemBox>
+          <p>장바구니에 담긴 상품이 없습니다.</p>
+          <small>원하는 상품을 장바구니에 담아보세요!</small>
+        </S.NoItemBox>
+      ) : (
+        <TotalPrice />
+      )}
     </S.CartPageLayout>
   );
 }

--- a/src/Pages/ProductDetailPage/ProductDetailPage.tsx
+++ b/src/Pages/ProductDetailPage/ProductDetailPage.tsx
@@ -39,7 +39,7 @@ function ProductDetailPage() {
     },
   });
 
-  const handlePostCart = async () => {
+  const handlePostCart = () => {
     if (token) {
       const cartData = {
         token: token,

--- a/src/Pages/ProductDetailPage/ProductDetailPage.tsx
+++ b/src/Pages/ProductDetailPage/ProductDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
@@ -10,6 +10,7 @@ import * as S from "./style";
 import { openModal } from "../../features/modalSlice";
 import useFetchProductDetail from "../../hooks/queries/useFetchProductDetail";
 import cartAPI from "../../API/cartAPI";
+import Loading from "../../components/common/Loading/Loading";
 
 function ProductDetailPage() {
   const navigate = useNavigate();

--- a/src/Pages/ProductDetailPage/ProductDetailPage.tsx
+++ b/src/Pages/ProductDetailPage/ProductDetailPage.tsx
@@ -90,6 +90,7 @@ function ProductDetailPage() {
             setCount={setCount}
             stock={productDetailData.stock || 0}
             productPrice={productDetailData.price}
+            isChecked={true}
           />
           <S.hr />
           <S.TotalPriceWrapper>

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import MainLayout, { SellerLayout } from "../components/layout/Layout";
 import LoginPage from "../Pages/LoginPage/LoginPage";
@@ -12,15 +13,18 @@ import { RootState } from "../store/store";
 import NotFound from "../Pages/NotFound/NotFound";
 import SellerAdminPage from "../Pages/SellerAdminPage/SellerAdminPage";
 import SellerRegisterPage from "../Pages/SellerRegisterPage/SellerRegisterPage";
+import withAuth from "./withAuth";
 
 function Router() {
-  const token = useAppSelector((state: RootState) => state.login.token);
+  // const token = useAppSelector((state: RootState) => state.login.token);
+  const ProtectedCartPage = withAuth(CartPage);
+
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<MainLayout />}>
           <Route path="/" element={<HomePage />} />
-          <Route path="/cart" element={token ? <CartPage /> : <NotFound />} />
+          <Route path="/cart" element={<ProtectedCartPage />} />
           {/* <Route path="/mypage" element={token ? <MyPage /> : <NotFound />} /> */}
           <Route path="/search" element={<SearchResultPage />} />
           <Route path="/products/:productId" element={<ProductDetailPage />} />

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -16,7 +16,6 @@ import SellerRegisterPage from "../Pages/SellerRegisterPage/SellerRegisterPage";
 import withAuth from "./withAuth";
 
 function Router() {
-  // const token = useAppSelector((state: RootState) => state.login.token);
   const ProtectedCartPage = withAuth(CartPage);
 
   return (
@@ -25,7 +24,6 @@ function Router() {
         <Route element={<MainLayout />}>
           <Route path="/" element={<HomePage />} />
           <Route path="/cart" element={<ProtectedCartPage />} />
-          {/* <Route path="/mypage" element={token ? <MyPage /> : <NotFound />} /> */}
           <Route path="/search" element={<SearchResultPage />} />
           <Route path="/products/:productId" element={<ProductDetailPage />} />
         </Route>

--- a/src/Router/withAuth.tsx
+++ b/src/Router/withAuth.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren, ReactElement } from "react";
+import { useAppSelector } from "../store/hooks";
+import { Navigate } from "react-router-dom";
+
+function withAuth<P>(
+  Component: React.ComponentType<PropsWithChildren<P>>
+): React.ComponentType<PropsWithChildren<P>> {
+  return function ProtectedRoute(
+    props: PropsWithChildren<P>
+  ): ReactElement | null {
+    const token = useAppSelector((state) => state.login.token);
+
+    if (!token) {
+      return <Navigate to="/notfound" replace />;
+    }
+
+    return <Component {...props} />;
+  };
+}
+
+export default withAuth;

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -1,18 +1,14 @@
 import React, { Dispatch, SetStateAction, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import AmountBtn from "../../common/AmountBtn/AmountBtn";
 import Button from "../../common/Button/Button";
 import Modal from "../../common/Modal/Modal";
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import { RootState } from "../../../store/store";
 import * as S from "./style";
-import {
-  OldDataResultsType,
-  ProductDetailType,
-} from "../../../types/Cart.type";
-import cartAPI from "../../../API/cartAPI";
+import { ProductDetailType } from "../../../types/Cart.type";
 import CheckCircleBtn from "../../common/CheckBtn/CheckCircleBtn";
-import { setPaymentAmount } from "../../../features/paymentAmountSlice";
+import { useDeleteCartItem } from "../../../hooks/queries/useDeleteCartItems";
 
 interface CartItemProps {
   cartItem: ProductDetailType;
@@ -22,18 +18,6 @@ interface CartItemProps {
   onToggle: () => void;
 }
 
-interface oldDataType {
-  count: number;
-  next: string | null; //"https://openmarket.weniv.co.kr/cart/?page=2"
-  previous: string | null;
-  results: OldDataResultsType[];
-}
-
-interface DeleteCartItemMutationDataType {
-  cart_item_id: number;
-  token: string;
-}
-
 function CartItem({
   cartItem,
   quantity,
@@ -41,57 +25,18 @@ function CartItem({
   isChecked,
   onToggle,
 }: CartItemProps) {
-  const dispatch = useAppDispatch();
   const { totalPrice, totalShippingFee } = useAppSelector(
     (state) => state.paymentAmount
   );
   const token = useAppSelector((state: RootState) => state.login.token) || "";
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [count, setCount] = useState(quantity);
-  const queryClient = useQueryClient();
   // console.log(cartItem);
 
-  const deleteCartItemMutation = useMutation(cartAPI.deleteCartItem, {
-    onSuccess: (data) => {
-      const itemPrice = cartItem.price;
-      const itemShippingFee = cartItem.shipping_fee;
-      dispatch(
-        setPaymentAmount({
-          totalPrice: totalPrice - itemPrice * count,
-          totalShippingFee: totalShippingFee - itemShippingFee,
-        })
-      );
-    },
-    onMutate: async (data: DeleteCartItemMutationDataType) => {
-      // 낙관적 업데이트를 덮어쓰지 않기위해 쿼리를 수동으로 삭제
-      await queryClient.cancelQueries({
-        queryKey: ["cartList", token],
-      });
-
-      // 이전값
-      const previousCartItems = queryClient.getQueryData(["cartList", token]);
-
-      // 새로운 값으로 낙관적 업데이트를 진행
-      queryClient.setQueryData(
-        ["cartList", token],
-        (oldData: oldDataType | undefined) => {
-          if (!oldData) return;
-
-          const filteredData = oldData.results.filter(
-            (item: OldDataResultsType) =>
-              item.cart_item_id !== data.cart_item_id
-          );
-          return { ...oldData, results: filteredData };
-        }
-      );
-
-      // 값이 들어있는 context 객체 반환
-      return { previousCartItems };
-    },
-    // mutation이 실패해서 데이터 업데이트가 되지 않았을때 onMutate에서 반환된 이전의 백업된 context를 사용하여 롤백 진행
-    onError: (_, context: any) => {
-      queryClient.setQueryData(["cartList", token], context.previousCartItems);
-    },
+  const { deleteCartItemMutation } = useDeleteCartItem({
+    totalPrice,
+    totalShippingFee,
+    cartItem,
   });
 
   const handleOpenDeleteModal = () => {

--- a/src/components/cart/CartItem/CartItem.tsx
+++ b/src/components/cart/CartItem/CartItem.tsx
@@ -37,6 +37,7 @@ function CartItem({
     totalPrice,
     totalShippingFee,
     cartItem,
+    count,
   });
 
   const handleOpenDeleteModal = () => {

--- a/src/components/common/AmountBtn/AmountBtn.tsx
+++ b/src/components/common/AmountBtn/AmountBtn.tsx
@@ -1,10 +1,9 @@
 import { useAppDispatch, useAppSelector } from "../../../store/hooks";
 import { RootState } from "../../../store/store";
 import * as S from "./style";
-import { QueryClient, useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import cartAPI from "../../../API/cartAPI";
 import { setPaymentAmount } from "../../../features/paymentAmountSlice";
-import useFetchCartItems from "../../../hooks/queries/useFetchCartItems";
 
 interface AmountBtnProps {
   count: number;
@@ -25,22 +24,20 @@ function AmountBtn({
   cartId,
   productPrice,
 }: AmountBtnProps) {
-  const queryClient = new QueryClient();
   const dispatch = useAppDispatch();
   const token = useAppSelector((state: RootState) => state.login.token) || "";
   const { totalPrice, totalShippingFee } = useAppSelector(
     (state) => state.paymentAmount
   );
-  // const { refetch } = useFetchCartItems(token);
-
+  const queryClient = useQueryClient();
   const updateQuantityMutation = useMutation(cartAPI.updateCartQuantity, {
-    onSuccess: () => {
-      // refetch();
+    onSuccess() {
+      queryClient.invalidateQueries(["cartList"]);
     },
   });
 
   const handleDecrease = () => {
-    if (count > 1) {
+    if (isChecked && count > 1) {
       setCount(count - 1);
     }
     if (isChecked && productId !== undefined && cartId !== undefined) {
@@ -64,7 +61,7 @@ function AmountBtn({
   };
 
   const handleIncrease = () => {
-    if (stock !== undefined && count < stock) {
+    if (isChecked && stock !== undefined && count < stock) {
       setCount(count + 1);
     }
     if (isChecked && productId !== undefined && cartId !== undefined) {

--- a/src/components/common/AmountBtn/AmountBtn.tsx
+++ b/src/components/common/AmountBtn/AmountBtn.tsx
@@ -31,11 +31,11 @@ function AmountBtn({
   const { totalPrice, totalShippingFee } = useAppSelector(
     (state) => state.paymentAmount
   );
-  const { refetch } = useFetchCartItems(token);
+  // const { refetch } = useFetchCartItems(token);
 
   const updateQuantityMutation = useMutation(cartAPI.updateCartQuantity, {
     onSuccess: () => {
-      refetch();
+      // refetch();
     },
   });
 
@@ -43,7 +43,7 @@ function AmountBtn({
     if (count > 1) {
       setCount(count - 1);
     }
-    if (productId !== undefined && cartId !== undefined) {
+    if (isChecked && productId !== undefined && cartId !== undefined) {
       const quantityData = {
         token: token,
         product_id: productId,
@@ -67,7 +67,7 @@ function AmountBtn({
     if (stock !== undefined && count < stock) {
       setCount(count + 1);
     }
-    if (productId !== undefined && cartId !== undefined) {
+    if (isChecked && productId !== undefined && cartId !== undefined) {
       const quantityData = {
         token: token,
         product_id: productId,

--- a/src/components/common/DropDown/DropDown.tsx
+++ b/src/components/common/DropDown/DropDown.tsx
@@ -14,7 +14,7 @@ function DropDown() {
     onSuccess: () => {
       removeCookie("token");
       dispatch(updateToken(null));
-      navigate("/");
+      // navigate("/");
     },
   });
 

--- a/src/components/common/Loading/Loading.tsx
+++ b/src/components/common/Loading/Loading.tsx
@@ -3,12 +3,19 @@ import Spinner from "../../../assets/images/spinner.gif";
 
 function Loading() {
   return (
-    <>
+    <SpinnerWrapper>
       <LoadingSpinner src={Spinner} alt="로딩" />
-    </>
+    </SpinnerWrapper>
   );
 }
 export default Loading;
+
+const SpinnerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
 
 const LoadingSpinner = styled.img`
   text-align: center;

--- a/src/hooks/queries/useDeleteCartItems.tsx
+++ b/src/hooks/queries/useDeleteCartItems.tsx
@@ -1,0 +1,75 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAppDispatch, useAppSelector } from "../../store/hooks";
+import cartAPI from "../../API/cartAPI";
+import { setPaymentAmount } from "../../features/paymentAmountSlice";
+import { OldDataResultsType, ProductDetailType } from "../../types/Cart.type";
+
+interface useDeleteCartItemType {
+  totalPrice: number;
+  totalShippingFee: number;
+  cartItem: ProductDetailType;
+}
+
+interface oldDataType {
+  count: number;
+  next: string | null; //"https://openmarket.weniv.co.kr/cart/?page=2"
+  previous: string | null;
+  results: OldDataResultsType[];
+}
+
+interface DeleteCartItemMutationDataType {
+  cart_item_id: number;
+  token: string;
+}
+
+export function useDeleteCartItem({
+  totalPrice,
+  totalShippingFee,
+  cartItem,
+}: useDeleteCartItemType) {
+  const dispatch = useAppDispatch();
+  const token = useAppSelector((state: any) => state.login.token) || "";
+  const queryClient = useQueryClient();
+
+  const deleteCartItemMutation = useMutation(cartAPI.deleteCartItem, {
+    onSuccess: (data: any) => {
+      const itemPrice = cartItem.price;
+      const itemShippingFee = cartItem.shipping_fee;
+      dispatch(
+        setPaymentAmount({
+          totalPrice: totalPrice - data.price * data.count,
+          totalShippingFee: totalShippingFee - data.shipping_fee,
+        })
+      );
+    },
+    onMutate: async (data: DeleteCartItemMutationDataType) => {
+      // 낙관적 업데이트를 덮어쓰지 않기위해 쿼리를 수동으로 삭제
+      await queryClient.cancelQueries({
+        queryKey: ["cartList", token],
+      });
+      // 이전값
+      const previousCartItems = queryClient.getQueryData(["cartList", token]);
+
+      // 새로운 값으로 낙관적 업데이트를 진행
+      queryClient.setQueryData(
+        ["cartList", token],
+        (oldData: oldDataType | undefined) => {
+          if (!oldData) return;
+          const filteredData = oldData.results.filter(
+            (item: OldDataResultsType) =>
+              item.cart_item_id !== data.cart_item_id
+          );
+          return { ...oldData, results: filteredData };
+        }
+      );
+      // 값이 들어있는 context 객체 반환
+      return { previousCartItems };
+    },
+    // mutation이 실패해서 데이터 업데이트가 되지 않았을때 onMutate에서 반환된 이전의 백업된 context를 사용하여 롤백 진행
+    onError: (_, context: any) => {
+      queryClient.setQueryData(["cartList", token], context.previousCartItems);
+    },
+  });
+
+  return { deleteCartItemMutation };
+}

--- a/src/hooks/queries/useDeleteCartItems.tsx
+++ b/src/hooks/queries/useDeleteCartItems.tsx
@@ -11,7 +11,7 @@ interface useDeleteCartItemType {
   count: number;
 }
 
-interface oldDataType {
+export interface oldDataType {
   count: number;
   next: string | null; //"https://openmarket.weniv.co.kr/cart/?page=2"
   previous: string | null;
@@ -29,9 +29,9 @@ export function useDeleteCartItem({
   cartItem,
   count,
 }: useDeleteCartItemType) {
+  const queryClient = useQueryClient();
   const dispatch = useAppDispatch();
   const token = useAppSelector((state: any) => state.login.token) || "";
-  const queryClient = useQueryClient();
 
   const deleteCartItemMutation = useMutation(cartAPI.deleteCartItem, {
     onSuccess: (data: any) => {
@@ -46,6 +46,7 @@ export function useDeleteCartItem({
     },
     onMutate: async (data: DeleteCartItemMutationDataType) => {
       // 낙관적 업데이트를 덮어쓰지 않기위해 쿼리를 수동으로 삭제
+
       await queryClient.cancelQueries({
         queryKey: ["cartList", token],
       });

--- a/src/hooks/queries/useDeleteCartItems.tsx
+++ b/src/hooks/queries/useDeleteCartItems.tsx
@@ -8,6 +8,7 @@ interface useDeleteCartItemType {
   totalPrice: number;
   totalShippingFee: number;
   cartItem: ProductDetailType;
+  count: number;
 }
 
 interface oldDataType {
@@ -26,6 +27,7 @@ export function useDeleteCartItem({
   totalPrice,
   totalShippingFee,
   cartItem,
+  count,
 }: useDeleteCartItemType) {
   const dispatch = useAppDispatch();
   const token = useAppSelector((state: any) => state.login.token) || "";
@@ -37,8 +39,8 @@ export function useDeleteCartItem({
       const itemShippingFee = cartItem.shipping_fee;
       dispatch(
         setPaymentAmount({
-          totalPrice: totalPrice - data.price * data.count,
-          totalShippingFee: totalShippingFee - data.shipping_fee,
+          totalPrice: totalPrice - itemPrice * count,
+          totalShippingFee: totalShippingFee - itemShippingFee,
         })
       );
     },

--- a/src/hooks/queries/useFetchCartItems.tsx
+++ b/src/hooks/queries/useFetchCartItems.tsx
@@ -6,7 +6,7 @@ import { useAppDispatch } from "../../store/hooks";
 
 const useFetchCartItems = (token: string) => {
   const dispatch = useAppDispatch();
-  const { data: cartList, refetch } = useFetchCartList(token);
+  const { data: cartList } = useFetchCartList(token);
   // console.log(cartList);
 
   const productIds = cartList.results.map((item: any) => {
@@ -52,7 +52,11 @@ const useFetchCartItems = (token: string) => {
     0
   );
 
-  return { cartItems, initialTotalPrice, initialDeliveryFee, refetch };
+  return {
+    cartItems,
+    initialTotalPrice,
+    initialDeliveryFee,
+  };
 };
 
 export default useFetchCartItems;


### PR DESCRIPTION
## 🔶작업사항
- 버그1) 장바구니에서 AmountBtn 수량 추가하고 페이지 나갔다가 
다시 장바구니로 돌아오면 처음 AmountBtn 수량으로 적용되어있음
- 버그2) 장바구니에 상품담고 체크박스 해제하면, totalPrice 가 2배로 되고, 체크박스는 해제가 되지않음 [] -> [ture] 상태
## 🔶변경로직
- 버그1) React-Query 에서 queryClient.invalidateQueries(["cartList"]);사용해서 최신 값 업데이트했음
- 버그2) 장바구니에 상품을 담았을 때 cartItems 상품이 비동기적으로 받아와져서 체크박스 상태값인 isCheckedArray 가 [] 빈 배열로 렌더링됨, useState는 처음 렌더링된 값을 상태값으로 넣기에 뒤에 비동기적으로 받아와진 값은 저장이 되지 않음.
따라서, useEffect를 이용해서 상품 값 받아오도록 함
